### PR TITLE
Fix windows syslog constructor

### DIFF
--- a/syslog_windows.go
+++ b/syslog_windows.go
@@ -10,5 +10,5 @@ import (
 
 // no syslog on windows, write to stdout
 func NewSyslog(config *Config) *Backend {
-	return &Backend{config.Level, log.New(os.Stdout, "", config.Flags), "", nil}
+	return &Backend{config.Level, log.New(os.Stdout, "", config.Flags), "", nil, false}
 }


### PR DESCRIPTION
C:\Users\Admin\go\go1.17.13\bin\go.exe build -o C:\Users\Admin\AppData\Local\Temp\GoLand\___1go_build_stella_cmd_api.exe stella/cmd/api #gosetup
# github.com/echa/log
..\..\vendor\github.com\echa\log\syslog_windows.go:13:74: too few values in Backend{...}